### PR TITLE
A bunch of improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ Icon
 .Spotlight-V100
 .Trashes
 .vagrant
-Vagrantfile
+/Vagrantfile
+/inventory

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ Icon
 .Spotlight-V100
 .Trashes
 .vagrant
+Vagrantfile
 test

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ Icon
 .Trashes
 .vagrant
 Vagrantfile
-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 ---
 language: python
 python: "2.7"
+
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq python-apt python-pycurl
-install:
-  - pip install ansible$ANSIBLE_VERSION
-script:
-  - echo localhost > inventory
-  - ansible-playbook --syntax-check -i inventory test/playbook.yml
-  - ansible-playbook -i inventory test/playbook.yml --connection=local -v
+
+install: pip install ansible$ANSIBLE_VERSION
+
+script: test/travis.sh
+
 env:
   global:
     - ANSIBLE_ROLES_PATH=$TRAVIS_BUILD_DIR/..

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
 script:
   - echo localhost > inventory
   - ansible-playbook --syntax-check -i inventory test.yml
-  - ansible-playbook -i inventory test.yml --connection=local --sudo
+  - ansible-playbook -e oracle_jdk_switcher_enabled=yes -i inventory test.yml --connection=local --sudo
 env:
   matrix:
     - ANSIBLE_VERSION='==1.6.10' # latest minor release of minimal supported version

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
 script:
   - echo localhost > inventory
   - ansible-playbook --syntax-check -i inventory test/playbook.yml
-  - ansible-playbook -i inventory test/playbook.yml --connection=local
+  - ansible-playbook -i inventory test/playbook.yml --connection=local -v
 env:
   global:
     - ANSIBLE_ROLES_PATH=$TRAVIS_BUILD_DIR/..

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,11 @@ install:
   - pip install ansible$ANSIBLE_VERSION
 script:
   - echo localhost > inventory
-  - ansible-playbook --syntax-check -i inventory test.yml
-  - ansible-playbook -e oracle_jdk_switcher_enabled=yes -i inventory test.yml --connection=local --sudo
+  - ansible-playbook --syntax-check -i inventory test/playbook.yml
+  - ansible-playbook -i inventory test/playbook.yml --connection=local
 env:
+  global:
+    - ANSIBLE_ROLES_PATH=$TRAVIS_BUILD_DIR/..
   matrix:
     - ANSIBLE_VERSION='==1.6.10' # latest minor release of minimal supported version
     - ANSIBLE_VERSION=''         # latest release available on pip repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,12 @@ before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq python-apt python-pycurl
 install:
-  - pip install ansible==1.5.0
+  - pip install ansible$ANSIBLE_VERSION
 script:
   - echo localhost > inventory
   - ansible-playbook --syntax-check -i inventory test.yml
   - ansible-playbook -i inventory test.yml --connection=local --sudo
+env:
+  matrix:
+    - ANSIBLE_VERSION='==1.6.10' # latest minor release of minimal supported version
+    - ANSIBLE_VERSION=''         # latest release available on pip repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.1.0 (not released)
 
-stuff coming soon...
+* Depends on `debconf` module, and therefore requires Ansible 1.6+ [GH-?]
 
 ## v1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.1.0 (not released)
 
 * Depends on `debconf` module, and therefore requires Ansible 1.6+ [GH-?]
+* Remove "Oracle JDK" task prefix, which is no longer required when using Ansible 1.4+ [GH-?]
 
 ## v1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v1.1.0 (not released)
 
+* Add the ability to install michaelklishin/jdk_switcher helper [GH-?]
+  Note that this new option is disabled by default.
 * Depends on `debconf` module, and therefore requires Ansible 1.6+ [GH-?]
 * Remove "Oracle JDK" task prefix, which is no longer required when using Ansible 1.4+ [GH-?]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# CHANGELOG for oracle-jdk Ansible Role
+
+## v1.1.0 (not released)
+
+stuff coming soon...
+
+## v1.0.1
+
+* Switch to ANXS organization
+
+## v1.0.0
+
+* Initial release
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## v1.1.0 (not released)
 
-* Add the ability to install michaelklishin/jdk_switcher helper [GH-?]
+* Add the ability to install michaelklishin/jdk_switcher helper [GH-1]
 
   **Note:** This new option is disabled by default.
-* Depends on `debconf` module, and therefore requires Ansible 1.6+ [GH-?]
-* Remove "Oracle JDK" task prefix, which is no longer required when using Ansible 1.4+ [GH-?]
+* Depend on `debconf` module, and therefore require Ansible 1.6+ [GH-1]
+* Remove "Oracle JDK" task prefix, which is no longer required when using Ansible 1.4+ [GH-1]
 
 ## v1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## v1.1.0 (not released)
 
 * Add the ability to install michaelklishin/jdk_switcher helper [GH-?]
-  Note that this new option is disabled by default.
+
+  **Note:** This new option is disabled by default.
 * Depends on `debconf` module, and therefore requires Ansible 1.6+ [GH-?]
 * Remove "Oracle JDK" task prefix, which is no longer required when using Ansible 1.4+ [GH-?]
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,6 @@
 
 oracle_jdk_java_versions: [7]             # A list of java versions you want to have installed (6, 7 and/or 8)
 oracle_jdk_java_version_default: 7        # The java version you want to be the system default
+
+oracle_jdk_switcher_enabled: no           # github.com/michaelklishin/jdk_switcher will be installed if this option is enabled
+oracle_jdk_switcher_version: master       # The git reference to download (a branch name, a tag name or a commit sha)

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   author: pjan vandaele
   company: ANXS
   description: "Installs the latest update of Oracle JDK version(s)"
-  min_ansible_version: 1.4
+  min_ansible_version: 1.6
   license: MIT
   platforms:
   - name: Ubuntu

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,24 +21,16 @@
     repo: 'deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu precise main'
     state: present
 
-- name: Oracle JDK | Accept the oracle license
-  shell: "echo {{item}} shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections"
+- name: Oracle JDK | Accept Oracle license
+  debconf:
+    name: "{{item}}"
+    setting: "shared/accepted-oracle-license-v1-1"
+    vtype: "select"
+    value: "true"
   with_items:
     - oracle-java6-installer
     - oracle-java7-installer
     - oracle-java8-installer
-
-# Only for ansible 1.6 and higher...
-# - name: Oracle JDK | Accept Oracle license
-#   debconf:
-#     name: "{{item}}"
-#     setting: "shared/accepted-oracle-license-v1-1"
-#     type: "select"
-#     value: "true"
-#   with_items:
-#     - oracle-java6-installer
-#     - oracle-java7-installer
-#     - oracle-java8-installer
 
 - name: Oracle JDK | Install JDK package(s)
   apt:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,3 +44,13 @@
     name: "oracle-java{{oracle_jdk_java_version_default}}-set-default"
     state: present
     update_cache: yes
+
+- name: Install jdk_switcher as a shell function
+  get_url: url=https://raw.githubusercontent.com/michaelklishin/jdk_switcher/{{ oracle_jdk_switcher_version }}/jdk_switcher.sh
+           dest=/etc/profile.d/jdk_switcher.sh
+           mode=644
+  when: oracle_jdk_switcher_enabled
+
+- name: Use jdk_switcher to activate the default java version
+  shell: bash -lc 'jdk_switcher use oraclejdk{{ oracle_jdk_java_version_default }}'
+  when: oracle_jdk_switcher_enabled

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,27 +1,27 @@
 # file: oracle-jdk/tasks/main.yml
 
-- name: Oracle-jdk | Make sure the ansible required dependencies are installed
+- name: Make sure the ansible required dependencies are installed
   apt:
     pkg: "{{item}}"
     state: present
   with_items: ["python-pycurl", "debconf"]
 
-- name: Oracle JDK | Add webupd8 repository apt-key
+- name: Add webupd8 repository apt-key
   apt_key:
     url: "http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0xC2518248EEA14886"
     state: present
 
-- name: Oracle JDK | Add webupd8 repository
+- name: Add webupd8 repository
   apt_repository:
     repo: 'deb http://ppa.launchpad.net/webupd8team/java/ubuntu precise main'
     state: present
 
-- name: Oracle JDK | Add webupd8 repository (src)
+- name: Add webupd8 repository (src)
   apt_repository:
     repo: 'deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu precise main'
     state: present
 
-- name: Oracle JDK | Accept Oracle license
+- name: Accept Oracle license
   debconf:
     name: "{{item}}"
     setting: "shared/accepted-oracle-license-v1-1"
@@ -32,14 +32,14 @@
     - oracle-java7-installer
     - oracle-java8-installer
 
-- name: Oracle JDK | Install JDK package(s)
+- name: Install JDK package(s)
   apt:
     name: "oracle-java{{item}}-installer"
     state: present
     update_cache: yes
   with_items: oracle_jdk_java_versions
 
-- name: Oracle JDK | Set the default Java version
+- name: Set the default Java version
   apt:
     name: "oracle-java{{oracle_jdk_java_version_default}}-set-default"
     state: present

--- a/test.yml
+++ b/test.yml
@@ -1,5 +1,0 @@
-- hosts: all
-  vars_files:
-    - 'defaults/main.yml'
-  tasks:
-    - include: 'tasks/main.yml'

--- a/test/playbook.yml
+++ b/test/playbook.yml
@@ -1,0 +1,18 @@
+---
+- name: Install Oracle JDKs
+
+  hosts: all
+
+  sudo: yes
+  sudo_user: root
+
+  roles:
+    - { 
+        role: oracle-jdk,
+
+        oracle_jdk_switcher_enabled:      yes,
+        oracle_jdk_switcher_version:      'e501c74033e475a0b6938987d912cf0c4b0baa06',
+        oracle_jdk_java_versions:         [6, 7, 8],
+        oracle_jdk_java_version_default:  8
+      }
+

--- a/test/playbook.yml
+++ b/test/playbook.yml
@@ -12,7 +12,7 @@
 
         oracle_jdk_switcher_enabled:      yes,
         oracle_jdk_switcher_version:      'e501c74033e475a0b6938987d912cf0c4b0baa06',
-        oracle_jdk_java_versions:         [6, 7, 8],
+        oracle_jdk_java_versions:         [7, 8],
         oracle_jdk_java_version_default:  8
       }
 

--- a/test/travis.sh
+++ b/test/travis.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo localhost > inventory
+ansible-playbook --syntax-check -i inventory test/playbook.yml || exit 1
+ansible-playbook -i inventory test/playbook.yml --connection=local -v || exit 2
+
+source /etc/profile.d/jdk_switcher.sh || exit 3
+
+echo "check default version:"
+java -version 2>&1 | grep 'java version' | grep -wE 'java version "1.8.0_.*"' || exit 4
+
+echo "check that expected oracle java versions are available:"
+for JAVA_VERSION in 6 7 8
+do
+  echo "Switch to OracleJDK $JAVA_VERSION"
+  jdk_switcher use oraclejdk$JAVA_VERSION
+  java -version 2>&1 | grep 'java version' | grep -wE "java version \"1.${JAVA_VERSION}.0_.*\"" || exit "99${JAVA_VERSION}"
+done

--- a/test/travis.sh
+++ b/test/travis.sh
@@ -10,7 +10,7 @@ echo "check default version:"
 java -version 2>&1 | grep 'java version' | grep -wE 'java version "1.8.0_.*"' || exit 4
 
 echo "check that expected oracle java versions are available:"
-for JAVA_VERSION in 6 7 8
+for JAVA_VERSION in 7 8
 do
   echo "Switch to OracleJDK $JAVA_VERSION"
   jdk_switcher use oraclejdk$JAVA_VERSION


### PR DESCRIPTION
**Summary of proposed Changes:**
- Add the ability to optionally install michaelklishin/jdk_switcher helper
- Adopt `debconf` module, and therefore requires Ansible 1.6+
- Remove "Oracle JDK" task prefix, which is no longer required when using Ansible 1.4+
- Use Travis CI tests to:
  - validate the role "as role"
  - check against different versions of Ansible
  - validate with `jdk_switcher` that expected JDKs are well installed

I hope you'll like to integrate all this stuff. I am looking forward to reading your feedback and I already thank you for the good work you've done so far :)

**Other feature ideas (but for separated pull requests)**

Please tell me if you are interested in following features:
- Add the ability to pin the JDK version to install (to solve problems like https://github.com/tbsalling/aismessages/pull/6)
- Provide a `Vagrantfile` sample to help people kick a local dev environment.
