### PR TITLE
Only accept Oracle license for wanted java versions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,14 +23,11 @@
 
 - name: Oracle JDK | Accept Oracle license
   debconf:
-    name: "{{item}}"
+    name: "oracle-java{{item}}-installer"
     setting: "shared/accepted-oracle-license-v1-1"
     vtype: "select"
     value: "true"
-  with_items:
-    - oracle-java6-installer
-    - oracle-java7-installer
-    - oracle-java8-installer
+  with_items: oracle_jdk_java_versions
 
 - name: Oracle JDK | Install JDK package(s)
   apt:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,7 @@
     setting: "shared/accepted-oracle-license-v1-1"
     vtype: "select"
     value: "true"
-  with_items: oracle_jdk_java_versions
+  with_items: '{{oracle_jdk_java_versions}}'
 
 - name: Oracle JDK | Install JDK package(s)
   apt:


### PR DESCRIPTION
I've made this change because I was having some troubles running this under Ansible 2.0.0.2 with the following options for `ansible-playbook`: `(...) -i 'localhost,' -u my_user -K --connection=local`.

I was running into the following problem:
![oracle_accept_license](https://cloud.githubusercontent.com/assets/2746590/12390683/10499ab4-bdda-11e5-9f73-5ddd96a09440.png)

I've then tried to force `sudo: false` on this specific task but no luck, got another problem:
![with_sudo_false](https://cloud.githubusercontent.com/assets/2746590/12390696/3d95bd72-bdda-11e5-82a6-8744081b567b.png)

I was just installing java version **8** btw.

Anyway, regardless of the issues I've stumbled upon I think this change makes total sense since there's no need to try to accept the license for java versions that we're not even trying to install.
And also, with this change it should still work for ansible 1.6+.
