### PR TITLE
Fix ansible 2.0+ deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,7 @@
     name: "oracle-java{{item}}-installer"
     state: present
     update_cache: yes
-  with_items: oracle_jdk_java_versions
+  with_items: '{{oracle_jdk_java_versions}}'
 
 - name: Oracle JDK | Set the default Java version
   apt:


### PR DESCRIPTION
Fix deprecation warning on Ansible 2.0+

![deprecation_warning](https://cloud.githubusercontent.com/assets/2746590/13748937/0c9a6a08-e9f7-11e5-8b6d-6031855204e2.png)
